### PR TITLE
Fixed 'perlbrew list' alignment

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -2133,7 +2133,7 @@ sub run_command_list {
     my $is_verbose = $self->{verbose};
 
     for my $i ($self->installed_perls) {
-        printf "%2s %-20s %-20s %s\n",
+        printf "%-2s%-20s %-20s %s\n",
             $i->{is_current} ? '*' : '',
             $i->{name},
             ( $is_verbose ?


### PR DESCRIPTION
This patch seeks to correct the issue below, where there is an extra character for the installed perls as compared to the installed libs:
```
  * perl-5.16.3
   perl-5.16.3@NAME

    perl-5.16.3
 * perl-5.16.3@NAME
```
